### PR TITLE
グループ指定（ユーザ指定）の場合、ルームをまたがらないパタンとカレンダーの共有予定のようなパタンを切り分けられるようにフィールド追加したことによる修正

### DIFF
--- a/Model/Behavior/CalendarTopicsBehavior.php
+++ b/Model/Behavior/CalendarTopicsBehavior.php
@@ -81,7 +81,8 @@ class CalendarTopicsBehavior extends CalendarAppBehavior {
 			'search_contents' => array(
 				'title', 'location', 'contact', 'description'
 			),
-			'users' => $shareUsers
+			'users' => $shareUsers,
+			'data' => array('is_in_room' => !(int)$shareUsers)
 		));
 		$model->CalendarEvent->saveTopics();
 		$model->CalendarEvent->Behaviors->unload('Topics.Topics');


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/675
