### PR TITLE
開始日を変更したときに開始日時を連動で変更させるのは正解であるが、そのとき「時刻」まで変えてしまって居たのは間違いだった。

### DIFF
--- a/webroot/js/calendars.js
+++ b/webroot/js/calendars.js
@@ -506,8 +506,15 @@ NetCommonsApp.controller('CalendarsDetailEdit',
            //
            var endTargetId = targetId.replace(/Start/g, 'End');
            $('#' + endTargetId).val($scope.detailStartDate);
+
+           // ここにくるのは時刻設定OFFのときなんだからやらなくていいのでは
            // 開始日の変更に合わせて開始時間情報の方も更新しておく
-           $scope.detailStartDatetime = momentStart.format('YYYY-MM-DD HH:mm');
+           var momentStartDatetime = moment($scope.detailStartDatetime);
+           momentStartDatetime.year(momentStart.year());
+           momentStartDatetime.month(momentStart.month());
+           momentStartDatetime.date(momentStart.date());
+           $scope.detailStartDatetime = momentStartDatetime.format('YYYY-MM-DD HH:mm');
+
            // 合わせて終了日時も自動更新
            $scope.fixEndTime();
          }


### PR DESCRIPTION
時刻情報は「開始日時」情報のものを保持するように変更した
https://github.com/NetCommons3/NetCommons3/issues/931