### PR TITLE
カレンダー予定登録で、毎回Blockデータが追加されるの対応　他

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ before_script:
   - git clone git://github.com/NetCommons3/NetCommons3 $NETCOMMONS_BUILD_DIR
   - cd $NETCOMMONS_BUILD_DIR
   - git checkout $NETCOMMONS_VERSION
-  - . tools/build/plugins/cakephp/travis/pre.sh
+  - travis_wait . tools/build/plugins/cakephp/travis/pre.sh
+  - . tools/build/plugins/cakephp/travis/environment.sh
 
 script:
   - . tools/build/plugins/cakephp/travis/main.sh

--- a/Controller/CalendarPlansController.php
+++ b/Controller/CalendarPlansController.php
@@ -148,7 +148,7 @@ class CalendarPlansController extends CalendarsAppController {
 		CalendarPermissiveRooms::setRoomPermRoles($this->roomPermRoles);
 
 		// 表示のための各種共通パラメータ設定
-		$this->_vars = $this->getVarsForShow();
+		$this->_vars = $this->_getVarsForShow();
 	}
 
 /**
@@ -495,7 +495,7 @@ class CalendarPlansController extends CalendarsAppController {
 		$this->request->data = $this->CalendarWorks->setCapForView2RequestData(
 			$capForView, $this->request->data);
 
-		$mailSettingInfo = $this->getMailSettingInfo();
+		$mailSettingInfo = $this->_getMailSettingInfo();
 
 		//reuqest->data['GroupUser']にある各共有ユーザの情報取得しセット
 		$shareUsers = array();
@@ -555,16 +555,16 @@ class CalendarPlansController extends CalendarsAppController {
 	}
 
 /**
- * getVarsForShow
+ * _getVarsForShow
  *
  * 個別予定表示用のCtp名および予定情報の取得
  *
  * @return void
  * @throws InternalErrorException
  */
-	public function getVarsForShow() {
+	protected function _getVarsForShow() {
 		$vars = array();
-		$this->setCalendarCommonVars($vars);
+		$this->_setCalendarCommonVars($vars);
 
 		$eventKey = Hash::get($this->request->params, 'key');
 		if ($eventKey) {
@@ -599,13 +599,13 @@ class CalendarPlansController extends CalendarsAppController {
 	}
 
 /**
- * getMailSettingInfo
+ * _getMailSettingInfo
  *
  * メール設定情報の取得
  *
  * @return array メール設定情報の配列
  */
-	public function getMailSettingInfo() {
+	protected function _getMailSettingInfo() {
 		$mailSettingInfo = $this->MailSetting->find('first', array(
 			'conditions' => array(
 				$this->MailSetting->alias . '.plugin_key' => 'calendars',

--- a/Controller/CalendarsAppController.php
+++ b/Controller/CalendarsAppController.php
@@ -46,14 +46,14 @@ class CalendarsAppController extends AppController {
 	);
 
 /**
- * getQueryParam
+ * _getQueryParam
  *
  * カレンダーURLクエリーパラメータ取り出し
  *
  * @param string $paramName 取り出したいパラメータ名
  * @return bool|mixed
  */
-	public function getQueryParam($paramName) {
+	protected function _getQueryParam($paramName) {
 		// ContainerがMainでないときは無視する
 		if (Hash::get($this->request->params, 'requested')) {
 			return false;
@@ -66,21 +66,21 @@ class CalendarsAppController extends AppController {
 		return false;
 	}
 /**
- * setCalendarCommonCurrent
+ * _setCalendarCommonCurrent
  *
  * カレンダー設定情報設定
  *
  * @param array &$vars カレンダー共通情報
  * @return void
  */
-	public function setCalendarCommonCurrent(&$vars) {
+	protected function _setCalendarCommonCurrent(&$vars) {
 		$vars['frame_key'] = Current::read('Frame.key');
 		$data = $this->CalendarFrameSetting->getFrameSetting();
 		Current::$current['CalendarFrameSetting'] = $data['CalendarFrameSetting'];
 	}
 
 /**
- * setDateTimeVars
+ * _setDateTimeVars
  *
  * 日付時刻変数設定
  *
@@ -88,7 +88,7 @@ class CalendarsAppController extends AppController {
  * @param object &$nctm NetCommonsTimeオブジェクト
  * @return void
  */
-	public function setDateTimeVars(&$vars, &$nctm) {
+	protected function _setDateTimeVars(&$vars, &$nctm) {
 		//現在のユーザTZ「考慮済」年月日時分秒を取得
 		$userNowYmdHis = $nctm->toUserDatetime('now');
 		$userNowArray = CalendarTime::transFromYmdHisToArray($userNowYmdHis);
@@ -99,9 +99,9 @@ class CalendarsAppController extends AppController {
 		$vars['year'] = intval($userNowArray['year']);
 		$vars['month'] = intval($userNowArray['month']);
 
-		$qYear = $this->getQueryParam('year');
-		$qMonth = $this->getQueryParam('month');
-		$qDay = $this->getQueryParam('day');
+		$qYear = $this->_getQueryParam('year');
+		$qMonth = $this->_getQueryParam('month');
+		$qDay = $this->_getQueryParam('day');
 		if ($qYear) {
 			if ($qYear < CalendarsComponent::CALENDAR_RRULE_TERM_UNTIL_YEAR_MIN) {
 				$qYear = CalendarsComponent::CALENDAR_RRULE_TERM_UNTIL_YEAR_MIN;
@@ -135,21 +135,21 @@ class CalendarsAppController extends AppController {
 	}
 
 /**
- * setCalendarCommonVars
+ * _setCalendarCommonVars
  *
  * カレンダー用共通変数設定
  *
  * @param array &$vars カレンダー用共通変数
  * @return void
  */
-	public function setCalendarCommonVars(&$vars) {
-		$this->setCalendarCommonCurrent($vars);
+	protected function _setCalendarCommonVars(&$vars) {
+		$this->_setCalendarCommonCurrent($vars);
 		$vars['CalendarFrameSetting'] = Current::read('CalendarFrameSetting');
 
 		$nctm = new NetCommonsTime();
 
 		//日付時刻変数を設定する
-		$this->setDateTimeVars($vars, $nctm);
+		$this->_setDateTimeVars($vars, $nctm);
 
 		//戻り先変数を設定する
 		//$this->setReturnVars($vars); ※未使用
@@ -301,7 +301,7 @@ class CalendarsAppController extends AppController {
 		}
 		// style指定がないときはデフォルト表示にしているときのはずです
 		// あるときは特殊画面から移動してます
-		$style = $this->getQueryParam('style');
+		$style = $this->_getQueryParam('style');
 		if ($style) {
 			$currentPath = $this->request->here(false);
 		} else {

--- a/Controller/CalendarsController.php
+++ b/Controller/CalendarsController.php
@@ -98,10 +98,10 @@ class CalendarsController extends CalendarsAppController {
 	public function index() {
 		$ctpName = '';
 		$vars = array();
-		$style = $this->getQueryParam('style');
+		$style = $this->_getQueryParam('style');
 		if (! $style) {
 			//style未指定の場合、CalendarFrameSettingモデルのdisplay_type情報から表示するctpを決める。
-			$this->setCalendarCommonCurrent($vars);
+			$this->_setCalendarCommonCurrent($vars);
 			$displayType = Current::read('CalendarFrameSetting.display_type');
 			if ($displayType == CalendarsComponent::CALENDAR_DISP_TYPE_SMALL_MONTHLY) {
 				$style = 'smallmonthly';
@@ -126,7 +126,7 @@ class CalendarsController extends CalendarsAppController {
 		$roomPermRoles = $this->CalendarEvent->prepareCalRoleAndPerm();
 		CalendarPermissiveRooms::setRoomPermRoles($roomPermRoles);
 
-		$ctpName = $this->getCtpAndVars($style, $vars);
+		$ctpName = $this->_getCtpAndVars($style, $vars);
 
 		$frameId = Current::read('Frame.id');
 		$languageId = Current::read('Language.id');
@@ -135,73 +135,73 @@ class CalendarsController extends CalendarsAppController {
 	}
 
 /**
- * getMonthlyVars
+ * _getMonthlyVars
  *
  * 月カレンダー用変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars 月（縮小用）データ
  */
-	public function getMonthlyVars($vars) {
-		$this->setCalendarCommonVars($vars);
+	protected function _getMonthlyVars($vars) {
+		$this->_setCalendarCommonVars($vars);
 		$vars['selectRooms'] = array();	//マージ前の暫定
 		return $vars;
 	}
 
 /**
- * getWeeklyVars
+ * _getWeeklyVars
  *
  * 週単位変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars 週単位データ
  */
-	public function getWeeklyVars($vars) {
-		$this->setCalendarCommonVars($vars);
+	protected function _getWeeklyVars($vars) {
+		$this->_setCalendarCommonVars($vars);
 		$vars['selectRooms'] = array();	//マージ前の暫定
-		$vars['week'] = $this->getQueryParam('week');
+		$vars['week'] = $this->_getQueryParam('week');
 		return $vars;
 	}
 
 /**
- * getDailyListVars
+ * _getDailyListVars
  *
  * 日単位（一覧）用変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars 日単位（一覧）データ
  */
-	public function getDailyListVars($vars) {
-		$this->setCalendarCommonVars($vars);
+	protected function _getDailyListVars($vars) {
+		$this->_setCalendarCommonVars($vars);
 		$vars['tab'] = 'list';
 		return $vars;
 	}
 
 /**
- * getDailyTimelineVars
+ * _getDailyTimelineVars
  *
  * 日単位（タイムライン）用変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars 日単位（タイムライン）データ
  */
-	public function getDailyTimelineVars($vars) {
-		$this->setCalendarCommonVars($vars);
+	protected function _getDailyTimelineVars($vars) {
+		$this->_setCalendarCommonVars($vars);
 		$vars['tab'] = 'timeline';
 		return $vars;
 	}
 
 /**
- * getMemberScheduleVars
+ * _getMemberScheduleVars
  *
  * スケジュール（会員順）用変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars スケジュール（会員順）データ
  */
-	public function getMemberScheduleVars($vars) {
+	protected function _getMemberScheduleVars($vars) {
 		$vars['sort'] = 'member';
-		$this->setCalendarCommonVars($vars);
+		$this->_setCalendarCommonVars($vars);
 
 		$vars['selectRooms'] = array();	//マージ前の暫定
 
@@ -227,16 +227,16 @@ class CalendarsController extends CalendarsAppController {
 	}
 
 /**
- * getTimeScheduleVars
+ * _getTimeScheduleVars
  *
  * スケジュール（時間順）用変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars スケジュール（時間順）データ
  */
-	public function getTimeScheduleVars($vars) {
+	protected function _getTimeScheduleVars($vars) {
 		$vars['sort'] = 'time';
-		$this->setCalendarCommonVars($vars);
+		$this->_setCalendarCommonVars($vars);
 
 		$vars['selectRooms'] = array();	//マージ前の暫定
 
@@ -262,19 +262,19 @@ class CalendarsController extends CalendarsAppController {
 	}
 
 /**
- * getDailyVars
+ * _getDailyVars
  *
  * 日次カレンダー変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars 日次カレンダー変数
  */
-	public function getDailyVars($vars) {
-		$tab = $this->getQueryParam('tab');
+	protected function _getDailyVars($vars) {
+		$tab = $this->_getQueryParam('tab');
 		if ($tab === 'timeline') {
-			$vars = $this->getDailyTimelineVars($vars);
+			$vars = $this->_getDailyTimelineVars($vars);
 		} else {
-			$vars = $this->getDailyListVars($vars);
+			$vars = $this->_getDailyListVars($vars);
 		}
 
 		$vars['selectRooms'] = array();	//マージ前の暫定
@@ -283,15 +283,15 @@ class CalendarsController extends CalendarsAppController {
 	}
 
 /**
- * getScheduleVars
+ * _getScheduleVars
  *
  * スケジュール変数取得
  *
  * @param array $vars カレンンダー情報
  * @return array $vars スケジュール変数
  */
-	public function getScheduleVars($vars) {
-		//$sort = $this->getQueryParam('sort');
+	protected function _getScheduleVars($vars) {
+		//$sort = $this->_getQueryParam('sort');
 		// スケジュール表示のときだけは直接覗くようにする(正式取得しない)
 		// 理由１：スケジュール表示は左カラムから表示されない
 		// 理由２：スケジュール表示の種別指定パラメータをデフォルト表示のときもqueryに入れている
@@ -299,15 +299,15 @@ class CalendarsController extends CalendarsAppController {
 		// 上記理由から直接見ないと処理できないし、直接見てもよそ様フレームと混同しないから
 		$sort = $this->request->query['sort'];
 		if ($sort === 'member') {
-			$vars = $this->getMemberScheduleVars($vars);
+			$vars = $this->_getMemberScheduleVars($vars);
 		} else {
-			$vars = $this->getTimeScheduleVars($vars);
+			$vars = $this->_getTimeScheduleVars($vars);
 		}
 		return $vars;
 	}
 
 /**
- * getCtpAndVars
+ * _getCtpAndVars
  *
  * ctpおよびvars取得
  *
@@ -315,38 +315,38 @@ class CalendarsController extends CalendarsAppController {
  * @param array &$vars カレンダー共通変数
  * @return string ctpNameを格納したstring
  */
-	public function getCtpAndVars($style, &$vars) {
+	protected function _getCtpAndVars($style, &$vars) {
 		$ctpName = '';
 		switch ($style) {
 			case 'smallmonthly':
 				$ctpName = 'smonthly';
-				$vars = $this->getMonthlyVars($vars);	//月カレンダー情報は、拡大・縮小共通
+				$vars = $this->_getMonthlyVars($vars);	//月カレンダー情報は、拡大・縮小共通
 				$vars['style'] = 'smallmonthly';
 				break;
 			case 'largemonthly':
 				$ctpName = 'lmonthly';
-				$vars = $this->getMonthlyVars($vars);	//月カレンダー情報は、拡大・縮小共通
+				$vars = $this->_getMonthlyVars($vars);	//月カレンダー情報は、拡大・縮小共通
 				$vars['style'] = 'largemonthly';
 				break;
 			case 'weekly':
 				$ctpName = 'weekly';
-				$vars = $this->getWeeklyVars($vars);
+				$vars = $this->_getWeeklyVars($vars);
 				$vars['style'] = 'weekly';
 				break;
 			case 'daily':
 				$ctpName = 'daily';
-				$vars = $this->getDailyVars($vars);
+				$vars = $this->_getDailyVars($vars);
 				$vars['style'] = 'daily';
 				break;
 			case 'schedule':
 				$ctpName = 'schedule';
-				$vars = $this->getScheduleVars($vars);
+				$vars = $this->_getScheduleVars($vars);
 				$vars['style'] = 'schedule';
 				break;
 			default:
 				//不明時は月（縮小）
 				$ctpName = 'smonthly';
-				$vars = $this->getMonthlyVars($vars);
+				$vars = $this->_getMonthlyVars($vars);
 				$vars['style'] = 'smallmonthly';
 		}
 

--- a/Model/Behavior/CalendarTopicsBehavior.php
+++ b/Model/Behavior/CalendarTopicsBehavior.php
@@ -77,6 +77,7 @@ class CalendarTopicsBehavior extends CalendarAppBehavior {
 		$model->CalendarEvent->Behaviors->load('Topics.Topics', array(
 			'fields' => array(
 				'path' => '/:plugin_key/calendar_plans/view/:content_key',
+				'summary' => array('description'),
 			),
 			'search_contents' => array(
 				'title', 'location', 'contact', 'description'

--- a/Test/Case/AllCalendarsTest.php
+++ b/Test/Case/AllCalendarsTest.php
@@ -26,7 +26,7 @@ class AllCalendarsTest extends NetCommonsTestSuite {
  */
 	public static function suite() {
 		$plugin = preg_replace('/^All([\w]+)Test$/', '$1', __CLASS__);
-		$suite = new CakeTestSuite(sprintf('All %s Plugin tests', $plugin));
+		$suite = new NetCommonsTestSuite(sprintf('All %s Plugin tests', $plugin));
 		$suite->addTestDirectoryRecursive(CakePlugin::path($plugin) . 'Test' . DS . 'Case');
 		return $suite;
 	}

--- a/View/Helper/CalendarPlanEditRepeatOptionHelper.php
+++ b/View/Helper/CalendarPlanEditRepeatOptionHelper.php
@@ -106,6 +106,7 @@ class CalendarPlanEditRepeatOptionHelper extends AppHelper {
 			'ng-model' => 'editRrule',
 			'ng-init' => "editRrule = '" . $editRrule . "'",
 			'ng-change' => "changeEditRrule(" . Current::read('Frame.id') . ",'" . $firstSibEditLink . "')",
+			'ng-click' => 'sending=true',
 		));
 		if (! $isRecurrence) {
 			$html .= '<p class="help-block text-right"><small>';

--- a/webroot/js/calendars.js
+++ b/webroot/js/calendars.js
@@ -570,13 +570,13 @@ NetCommonsApp.controller('CalendarsDetailEdit',
            return;
          }
          //
-         /* delete for issue#945
          if ($scope.detailEndDate != '') {
            $('#' + targetId).val($scope.detailEndDate);
-           $scope.detailStartEndDatetime = momentEnd.format('YYYY-MM-DD HH:mm');
-           $scope.fixStartTime();
-         }
-         */
+            /* delete for issue#945
+               $scope.detailStartEndDatetime = momentEnd.format('YYYY-MM-DD HH:mm');
+               $scope.fixStartTime();
+             */
+          }
        };
         /**
          * 終了日時変更時処理
@@ -589,13 +589,13 @@ NetCommonsApp.controller('CalendarsDetailEdit',
            return;
          }
          //
-         /* delete for issue#945
          if ($scope.detailEndDatetime != '') {
            $('#' + targetId).val($scope.detailEndDatetime);
            $scope.detailStartEndDate = momentEnd.format('YYYY-MM-DD');
-           $scope.fixStartTime();
+           /* delete for issue#945
+               $scope.fixStartTime();
+           */
          }
-         */
        };
 
        $scope.changeYearMonth = function(prototypeUrl) {

--- a/webroot/js/calendars.js
+++ b/webroot/js/calendars.js
@@ -531,7 +531,7 @@ NetCommonsApp.controller('CalendarsDetailEdit',
        };
         /**
          * 終了日時に合うように開始日時更新
-         */
+         * delete for issue#945
         $scope.fixStartTime = function() {
           var momentStart = moment($scope.detailStartDatetime || null);
           var momentEnd = moment($scope.detailEndDatetime);
@@ -539,6 +539,7 @@ NetCommonsApp.controller('CalendarsDetailEdit',
             $scope.detailStartDatetime = momentEnd.add(-1, 'hours').format('YYYY-MM-DD HH:mm:ss');
           }
         };
+         */
         /**
          * 開始日時変更時処理
          */
@@ -569,11 +570,13 @@ NetCommonsApp.controller('CalendarsDetailEdit',
            return;
          }
          //
+         /* delete for issue#945
          if ($scope.detailEndDate != '') {
            $('#' + targetId).val($scope.detailEndDate);
            $scope.detailStartEndDatetime = momentEnd.format('YYYY-MM-DD HH:mm');
            $scope.fixStartTime();
          }
+         */
        };
         /**
          * 終了日時変更時処理
@@ -586,11 +589,13 @@ NetCommonsApp.controller('CalendarsDetailEdit',
            return;
          }
          //
+         /* delete for issue#945
          if ($scope.detailEndDatetime != '') {
            $('#' + targetId).val($scope.detailEndDatetime);
            $scope.detailStartEndDate = momentEnd.format('YYYY-MM-DD');
            $scope.fixStartTime();
          }
+         */
        };
 
        $scope.changeYearMonth = function(prototypeUrl) {


### PR DESCRIPTION
カレンダー予定登録で、毎回Blockデータが追加される #898　Migration処理の追加
繰返し予定の編集で sending=true #966　ボタンのdisabled化
カレンダーの全会員向けRolesRoom.role_key #820 全会員のrole_keyの取り出し、およびデフォルト値の扱い
CalendarPermissionモデルのalias #809
