### PR TITLE
カレンダーで、マイルームで予定を削除したのに、削除後にホームのカレンダーに戻ってしまうことへの対応

### DIFF
--- a/webroot/js/calendars.js
+++ b/webroot/js/calendars.js
@@ -745,6 +745,9 @@ NetCommonsApp.controller('CalendarsDetailEdit',
          if (action != '') {
            url = url + '?action=' + action;
          }
+         if ($scope.data.frameId) {
+           url = url + '&frame_id=' + $scope.data.frameId;
+         }
          if (firstSibEventId > 0) {
            url = url + '&first_sib_event_id=' + firstSibEventId;
          }


### PR DESCRIPTION
refs https://github.com/NetCommons3/NetCommons3/issues/1116
この修正でまぎれたバグ