### PR TITLE
fix:予約が二重に表示されないようにCalendarEvent.idでソートして取得するように修正

### DIFF
--- a/Controller/CalendarsAppController.php
+++ b/Controller/CalendarsAppController.php
@@ -236,13 +236,20 @@ class CalendarsAppController extends AppController {
 				$order = array(
 						'TrackableCreator' . '.handlename',
 						'CalendarEvent' . '.dtstart',
+						'CalendarEvent' . '.id',
 						);
 			} else { //時間順
-				$order = array('CalendarEvent' . '.dtstart');
+				$order = array(
+						'CalendarEvent' . '.dtstart',
+						'CalendarEvent' . '.id',
+						);
 			}
 		} else {
 			//$order = array('CalendarEvent' . '.start_date');
-			$order = array('CalendarEvent' . '.dtstart');
+			$order = array(
+					'CalendarEvent' . '.dtstart',
+					'CalendarEvent' . '.id',
+				);
 		}
 
 		//room_idとspace_idの対応表を載せておく。

--- a/Controller/CalendarsAppController.php
+++ b/Controller/CalendarsAppController.php
@@ -234,22 +234,22 @@ class CalendarsAppController extends AppController {
 				//$order = array('TrackableCreator' . '.username');
 				//$order = array('TrackableCreator' . '.handlename');
 				$order = array(
-						'TrackableCreator' . '.handlename',
-						'CalendarEvent' . '.dtstart',
-						'CalendarEvent' . '.id',
-						);
+					'TrackableCreator' . '.handlename',
+					'CalendarEvent' . '.dtstart',
+					'CalendarEvent' . '.id',
+				);
 			} else { //時間順
 				$order = array(
-						'CalendarEvent' . '.dtstart',
-						'CalendarEvent' . '.id',
-						);
+					'CalendarEvent' . '.dtstart',
+					'CalendarEvent' . '.id',
+				);
 			}
 		} else {
 			//$order = array('CalendarEvent' . '.start_date');
 			$order = array(
-					'CalendarEvent' . '.dtstart',
-					'CalendarEvent' . '.id',
-				);
+				'CalendarEvent' . '.dtstart',
+				'CalendarEvent' . '.id',
+			);
 		}
 
 		//room_idとspace_idの対応表を載せておく。


### PR DESCRIPTION
繰り返し予約で作成された予約を1件だけ修正した際に、他のレコードが２レコードできてしまっているため、表示時に同じ予約は必ず上書きされるように修正しました。
よろしければマージしてください。